### PR TITLE
Allow URLs with non-ASCII characters to be used in redirects.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 == Changelog ==
 
+= 0.4 =
+* Remove usage of `filter_var()` to support domains with non-ASCII characters.
+
 = 0.3 =
 * Add WP-CLI commands.
 

--- a/hm-redirects.php
+++ b/hm-redirects.php
@@ -5,7 +5,7 @@
  * @package hm-redirects
  *
  * Description: Handles redirects in a scalable manner.
- * Version: 0.3
+ * Version: 0.4
  * Author: Human Made Limited
  * Author URI: https://humanmade.com/
  * Text Domain: hm-redirects

--- a/includes/handle-redirects.php
+++ b/includes/handle-redirects.php
@@ -93,9 +93,8 @@ function get_redirect_uri( $url ) {
 		return false;
 	}
 
-	if ( false === filter_var( $to_url, FILTER_VALIDATE_URL ) ) {
-		$to_url = home_url() . $redirect_post->post_excerpt;
-	}
+	// If the URL is only a path, prefix it with the `home_url()`.
+	$to_url = Utilities\prefix_path( $to_url );
 
 	return wp_sanitize_redirect( $to_url );
 }

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -37,10 +37,6 @@ function normalise_url( $url ) {
 		return new WP_Error( 'invalid-redirect-url', esc_html__( 'The URL does not validate', 'hm-redirects' ) );
 	}
 
-	if ( false === filter_var( prefix_path( $url ), FILTER_VALIDATE_URL ) ) {
-		return new WP_Error( 'invalid-redirect-url', esc_html__( 'The URL does not validate', 'hm-redirects' ) );
-	}
-
 	// Break up the URL into it's constituent parts.
 	$components = wp_parse_url( $url );
 

--- a/tests/test-utilities.php
+++ b/tests/test-utilities.php
@@ -40,7 +40,6 @@ class Utilities_Test extends WP_UnitTestCase {
 		return [
 			[ 'http://example.com' ], // No path.
 			[ 'http://url%20invalid%20charcaters' ], // Invalid character.
-			[ '/invalidcharacters¡™£¢∞§¶•ªº%5B%5D/here' ], // Invalid character.
 		];
 	}
 


### PR DESCRIPTION
The `FILTER_VALIDATE_URL` flag for `filter_var()` does not support non-ASCII characters. As such it returns `false` even for valid URLs with non-ASCII characters.

This causes full URLs to always be preprended with the `home_url()`, breaking redirects.