### PR TITLE
Fix class name in arguements to add_command

### DIFF
--- a/hm-redirects.php
+++ b/hm-redirects.php
@@ -28,5 +28,5 @@ require_once __DIR__ . '/includes/utilities.php';
 
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	require_once( __DIR__ . '/includes/class-cli-commands.php' );
-	WP_CLI::add_command( 'hm-redirects', 'HM\\Redirects\\CLI\\Commands' );
+	WP_CLI::add_command( 'hm-redirects', 'HM\\Redirects\\CLI\\CLI_Commands' );
 }


### PR DESCRIPTION
In the update to version 0.4.1, the class `Commands` was changec to `CLI_Commands`.

[This line](https://github.com/humanmade/hm-redirects/blob/master/hm-redirects.php#L31) was left unchanged.

This PR fixes that.
I changed the argument to `add_command` assuming that the file and class name were changed for a reason.

Thanks!