### PR TITLE
Add a new 'visit' link to the redirects list.

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -96,14 +96,16 @@ function row_actions( $actions, $post ) {
 	}
 
 	$url = get_the_title( $post );
-	$aria_label = esc_html( sprintf( __( 'Visit %s', 'hm-redirects'), $url ) );
+	$url = get_the_title( $post );
+	/* translators: %s: Redirect source URL */
+	$aria_label = esc_html( sprintf( __( 'Visit %s', 'hm-redirects' ), $url ) );
 	return array_merge(
 		[
 			'visit' => sprintf(
 				'<a target="_blank" href="%s" aria-label="%s">%s</a>',
 				esc_url( $url ),
 				$aria_label,
-				esc_html__( 'Visit', 'hm-redirects')
+				esc_html__( 'Visit', 'hm-redirects' )
 			),
 		],
 		$actions

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -96,7 +96,6 @@ function row_actions( $actions, $post ) {
 	}
 
 	$url = get_the_title( $post );
-	$url = get_the_title( $post );
 	/* translators: %s: Redirect source URL */
 	$aria_label = esc_html( sprintf( __( 'Visit %s', 'hm-redirects' ), $url ) );
 	return array_merge(

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -19,6 +19,7 @@ function setup() {
 	add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\\enqueue_scripts' );
 	add_action( 'manage_' . Redirects_Post_Type\SLUG . '_posts_custom_column', __NAMESPACE__ . '\\posts_columns_content', 10, 2 );
 	add_filter( 'manage_' . Redirects_Post_Type\SLUG . '_posts_columns', __NAMESPACE__ . '\\filter_posts_columns' );
+	add_filter( 'post_row_actions', __NAMESPACE__ . '\\row_actions', 10, 2 );
 	add_action( 'plugins_loaded', __NAMESPACE__ . '\\load_plugin_textdomain' );
 	add_action( 'save_post', __NAMESPACE__ . '\\handle_redirect_saving', 13 );
 }
@@ -81,6 +82,32 @@ function posts_columns_content( string $column, int $post_id ) {
 	if ( $column === 'status' ) {
 		echo intval( $post->post_content_filtered );
 	}
+}
+
+/**
+ * Add a new action to visit the redirected link.
+ *
+ * @param array   $actions Current row actions.
+ * @param WP_Post $post Current row post.
+ */
+function row_actions( $actions, $post ) {
+	if ( $post->post_status === 'trash' ) {
+		return $actions;
+	}
+
+	$url = get_the_title( $post );
+	$aria_label = esc_html( sprintf( __( 'Visit %s', 'hm-redirects'), $url ) );
+	return array_merge(
+		[
+			'visit' => sprintf(
+				'<a target="_blank" href="%s" aria-label="%s">%s</a>',
+				esc_url( $url ),
+				$aria_label,
+				esc_html__( 'Visit', 'hm-redirects')
+			),
+		],
+		$actions
+	);
 }
 
 /**


### PR DESCRIPTION
Sometimes a visit row action can be handy to test the redirect. This PR adds a new Visit link to every row in the redirections list that opens the URL in a new tab.

![Captura de pantalla 2020-05-27 a las 9 12 49](https://user-images.githubusercontent.com/1516569/82989095-6d24f380-9ffa-11ea-965e-7c32f79323d7.png)
