### PR TITLE
Avoid excessive sanitisation

### DIFF
--- a/includes/handle-redirects.php
+++ b/includes/handle-redirects.php
@@ -30,7 +30,7 @@ function maybe_do_redirect() {
 		return false;
 	}
 
-	$path = untrailingslashit( str_replace( wp_parse_url( home_url(), PHP_URL_PATH ), '', sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) ) );
+	$path = untrailingslashit( str_replace( wp_parse_url( home_url(), PHP_URL_PATH ), '', wp_unslash( $_SERVER['REQUEST_URI'] ) ) );
 
 	/**
 	 * Filter the request path before searching for a matching redirect.


### PR DESCRIPTION
We already sanitise URLs later. By calling sanitize_text_field(), this inadvertently was stripping percent-encoded special characters.

Fixes #46, see https://github.com/humanmade/altis-seo/issues/119