### PR TITLE
Match normalization for CLI to UI

### DIFF
--- a/includes/class-cli-commands.php
+++ b/includes/class-cli-commands.php
@@ -230,8 +230,8 @@ class CLI_Commands extends WP_CLI_Command {
 			}
 
 			$redirect = Utilities\insert_redirect(
-				$redirect_from,
-				esc_url_raw( $redirect_to ),
+				Utilities\normalise_url( Utilities\sanitise_and_normalise_url( $redirect_from ) ),
+				Utilities\sanitise_and_normalise_url( $redirect_to ),
 				absint( $status )
 			);
 


### PR DESCRIPTION
The UI decodes all URL-encoded strings in order to generate a canonical URL. The import command should produce the same result after import.

Fixes #50.