### PR TITLE
Preserve URL parameters

### DIFF
--- a/includes/handle-redirects.php
+++ b/includes/handle-redirects.php
@@ -88,6 +88,11 @@ function get_redirect_uri( $url ) {
 	// If the URL is only a path, prefix it with the `home_url()`.
 	$to_url = Utilities\prefix_path( $to_url );
 
+	// If there were any paramters in the original URL, append them to the new URL.
+	if ( ! empty( $_SERVER['QUERY_STRING'] ) ) {
+		$to_url .= '/?'.$_SERVER['QUERY_STRING'];
+	}
+
 	return wp_sanitize_redirect( $to_url );
 }
 

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -47,8 +47,11 @@ function sanitise_and_normalise_url( $unsafe_url ) {
 		$unsafe_url = add_leading_slash( $unsafe_url );
 	}
 
+	// remove any parameters and trailing slash from the url.
+	$clean_url = rtrim( strtok( $unsafe_url, '?' ), '/' );
+
 	// We now can safely escape the URL.
-	$url = esc_url_raw( $unsafe_url );
+	$url = esc_url_raw( $clean_url );
 
 	return $url;
 }


### PR DESCRIPTION
### Issue 
Currently a redirect doesn't preserve any parameters in the URL.
Redirecting `old-url` to `new-url` when there are parameters in the URL causes a 404.

### Solution
When a URL contains a parameter: `https://dev.altis.dev/old-url/?utm_content=search` it should redirect to the appropriate url and keep the parameters : `https://dev.altis.dev/new-url/?utm_content=search`

