### PR TITLE
Support preserving URL Query Parameters

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -193,11 +193,11 @@ function handle_redirect_saving( $post_id ) {
 
 	// phpcs:disable WordPress.VIP.ValidatedSanitizedInput
 	// We're using a custom sanitisation function.
-	$data = sanitise_and_normalise_redirect_data(
-		wp_unslash( $_POST['hm_redirects_from_url'] ),
-		wp_unslash( $_POST['hm_redirects_to_url'] ),
-		wp_unslash( $_POST['hm_redirects_status_code'] )
-	);
+	$data = [
+		'from_url' => wp_unslash( $_POST['hm_redirects_from_url'] ),
+		'to_url' => wp_unslash( $_POST['hm_redirects_to_url'] ),
+		'status_code' => wp_unslash( $_POST['hm_redirects_status_code'] )
+	];
 	// phpcs:enable
 
 	$redirect_id = Utilities\insert_redirect( $data['from_url'], $data['to_url'], $data['status_code'], $post_id );
@@ -215,11 +215,8 @@ function handle_redirect_saving( $post_id ) {
  * @return array
  */
 function sanitise_and_normalise_redirect_data( $unsafe_from, $unsafe_to, $unsafe_status_code ) {
-	return [
-		'from_url'    => Utilities\normalise_url( Utilities\sanitise_and_normalise_url( $unsafe_from ) ),
-		'to_url'      => Utilities\sanitise_and_normalise_url( $unsafe_to ),
-		'status_code' => absint( $unsafe_status_code ),
-	];
+	_deprecated_function( __FUNCTION__, '0.6.2', 'HM\\Redirects\\Utilities\\sanitise_and_normalise_redirect_data' );
+	return Utilities\sanitise_and_normalise_redirect_data( $unsafe_from, $unsafe_to, $unsafe_status_code );
 }
 
 /**

--- a/includes/class-cli-commands.php
+++ b/includes/class-cli-commands.php
@@ -230,8 +230,8 @@ class CLI_Commands extends WP_CLI_Command {
 			}
 
 			$redirect = Utilities\insert_redirect(
-				Utilities\normalise_url( Utilities\sanitise_and_normalise_url( $redirect_from ) ),
-				Utilities\sanitise_and_normalise_url( $redirect_to ),
+				$redirect_from,
+				$redirect_to,
 				absint( $status )
 			);
 

--- a/includes/handle-redirects.php
+++ b/includes/handle-redirects.php
@@ -90,7 +90,8 @@ function get_redirect_uri( $url ) {
 
 	// If there were any query parameters in the original URL, append them to the new URL.
 	if ( ! empty( $_SERVER['QUERY_STRING'] ) ) {
-		$to_url .= '/?'.$_SERVER['QUERY_STRING'];
+		list( , $unknown_parameters ) = Utilities\split_query_parameters( $_SERVER['QUERY_STRING'] );
+		$to_url = add_query_arg( urlencode_deep( $unknown_parameters ), $to_url );
 	}
 
 	return wp_sanitize_redirect( $to_url );

--- a/includes/handle-redirects.php
+++ b/includes/handle-redirects.php
@@ -88,6 +88,11 @@ function get_redirect_uri( $url ) {
 	// If the URL is only a path, prefix it with the `home_url()`.
 	$to_url = Utilities\prefix_path( $to_url );
 
+	// If there were any query parameters in the original URL, append them to the new URL.
+	if ( ! empty( $_SERVER['QUERY_STRING'] ) ) {
+		$to_url .= '/?'.$_SERVER['QUERY_STRING'];
+	}
+
 	return wp_sanitize_redirect( $to_url );
 }
 

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -47,8 +47,11 @@ function sanitise_and_normalise_url( $unsafe_url ) {
 		$unsafe_url = add_leading_slash( $unsafe_url );
 	}
 
+	// Remove any parameters and trailing slash from the url.
+	$clean_url = rtrim( strtok( $unsafe_url, '?' ), '/' );
+
 	// We now can safely escape the URL.
-	$url = esc_url_raw( $unsafe_url );
+	$url = esc_url_raw( $clean_url );
 
 	return $url;
 }

--- a/tests/class-handle-redirects-test.php
+++ b/tests/class-handle-redirects-test.php
@@ -9,6 +9,7 @@ namespace HM\Redirects\Tests;
 
 use HM\Redirects\Handle_Redirects;
 use HM\Redirects\Post_Type as Redirects_Post_Type;
+use HM\Redirects\Utilities;
 use WP_UnitTestCase;
 
 /**
@@ -48,12 +49,21 @@ class Handle_Redirects_Test extends WP_UnitTestCase {
 	/**
 	 * Provides valid test URLS.
 	 *
+	 * From, To, Status, Request, Result.
+	 *
 	 * @return array
 	 */
 	public function provider_redirect_uri_valid() {
 		return [
-			[ '/original-post', '/redirected-post', 301 ],
-			[ '/original-post?with=query-param', '/redirected-post?with=query-param', 303 ],
+			// Straight redirect.
+			[ '/original-post', '/redirected-post', '/original-post', '/redirected-post', 301 ],
+			[ '/?go=here', '/redirected-post', '/?go=here', '/redirected-post', 301 ],
+			// Preserves query string parameters/
+			[ '/original-post', '/redirected-post', '/original-post?with=query-param', '/redirected-post?with=query-param', 303 ],
+			[ '/original-post', '/redirected-post?with=query-param', '/original-post', '/redirected-post?with=query-param', 303 ],
+			[ '/original-post', '/redirected-post?with=query-param', '/original-post?with=query-param', '/redirected-post?with=query-param', 304 ],
+			[ '/original-post', '/redirected-post?with=query-param', '/original-post?diff=query-param', '/redirected-post?with=query-param&diff=query-param', 303 ],
+			[ '/original-post?b=c&a=b', '/redirected-post', '/original-post?a=b&b=c&foo=bar', '/redirected-post?foo=bar', 301 ],
 		];
 	}
 
@@ -83,21 +93,18 @@ class Handle_Redirects_Test extends WP_UnitTestCase {
 	 *
 	 * @dataProvider provider_redirect_uri_valid
 	 *
-	 * @param string $original_url Original URL.
-	 * @param string $expected_result Expected result.
+	 * @param string $from From URL.
+	 * @param string $to To URL.
+	 * @param string $request Requested URL.
+	 * @param string $expected_result Expected resulting URL.
+	 * @param int $status_code Redirect status code.
+	 * @return void
 	 */
-	public function test_get_redirect_uri_valid_urls( $original_url, $expected_result ) {
+	public function test_get_redirect_uri_valid_urls( $from, $to, $request, $expected_result, $status_code ) {
 
-		$p = $this->factory->post->create(
-			[
-				'post_title'   => 'Test Post',
-				'post_name'    => md5( $original_url ),
-				'post_type'    => Redirects_Post_Type\SLUG,
-				'post_excerpt' => $expected_result,
-			]
-		);
+		$p = Utilities\insert_redirect( $from, $to, $status_code );
 
-		$result = Handle_Redirects\get_redirect_uri( $original_url );
+		$result = Handle_Redirects\get_redirect_uri( $request );
 		$this->assertEquals( home_url() . $expected_result, $result );
 
 		wp_delete_post( $p );

--- a/tests/class-utilities-test.php
+++ b/tests/class-utilities-test.php
@@ -77,6 +77,8 @@ class Utilities_Test extends WP_UnitTestCase {
 			[ 'only/the/path', '/only/the/path' ],
 			// Relative URL, with query parameter.
 			[ '/a/path/?with=queryparam', '/a/path/?with=queryparam' ],
+			// Ordered query parameters.
+			[ '/a/path/?c=d&a=b', '/a/path/?a=b&c=d' ],
 			// Relative URL, with query parameter using brackets.
 			[ '/a/path/withbrakets?foo[bar]=baz', '/a/path/withbrakets?foo%5Bbar%5D=baz' ],
 			// Relative URL, with encoded spaces.


### PR DESCRIPTION
Uses an option to store query parameters that should be accounted for as redirect targets. These are removed during sanitisation and normalisation and then any unknown query parameters are re-appended after finding a matching redirect rule.

Preserves the ability to add redirects from URLs with query strings. It normalises the query string to sort the keys.

This will really need some migration tool adding before its ready.

Open to thoughts and suggestions for improvements or alternative approaches.