### PR TITLE
Don't output view link for all post types.

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -91,7 +91,7 @@ function posts_columns_content( string $column, int $post_id ) {
  * @param WP_Post $post Current row post.
  */
 function row_actions( $actions, $post ) {
-	if ( $post->post_status === 'trash' ) {
+	if ( $post->post_status === 'trash' || $post->post_type !== Redirects_Post_Type\SLUG ) {
 		return $actions;
 	}
 


### PR DESCRIPTION
On the HM Redirects post type list view in the admin, a custom row action 'Visit' is added, that takes you to the redirected link. 

The problem is that this 'Visit' row action is output for all post types. e.g. posts. And for non-redirect posts it is broken causing links like `http://Hello%20world!`. Also its confusing as now there are both 'View' and a 'Visit' links. 