### PR TITLE
Fix php 8.1 deprecation warning.

### DIFF
--- a/hm-redirects.php
+++ b/hm-redirects.php
@@ -5,7 +5,7 @@
  * @package hm-redirects
  *
  * Description: Handles redirects in a scalable manner.
- * Version: 0.7.0
+ * Version: 0.7.2
  * Author: Human Made Limited
  * Author URI: https://humanmade.com/
  * Text Domain: hm-redirects

--- a/includes/handle-redirects.php
+++ b/includes/handle-redirects.php
@@ -30,7 +30,7 @@ function maybe_do_redirect() {
 		return false;
 	}
 
-	$path = untrailingslashit( str_replace( wp_parse_url( home_url(), PHP_URL_PATH ), '', wp_unslash( $_SERVER['REQUEST_URI'] ) ) );
+	$path = untrailingslashit( str_replace( (string) wp_parse_url( home_url(), PHP_URL_PATH ), '', wp_unslash( $_SERVER['REQUEST_URI'] ) ) );
 
 	/**
 	 * Filter the request path before searching for a matching redirect.


### PR DESCRIPTION
Related issue : https://github.com/humanmade/hm-redirects/issues/66

PHP 8.1 shows the following error:

>PHP Deprecated:  str_replace(): Passing null to parameter #1($search) of type array|string is deprecated in /usr/src/app/vendor/humanmade/hm-redirects/includes/handle-redirects.php on line 33

This PR resolves the deprecation warning.