### PR TITLE
Remove unused HTTP codes

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -117,14 +117,12 @@ function row_actions( $actions, $post ) {
  * @param WP_Post $post The currently edited post.
  */
 function output_meta_box( WP_Post $post ) {
-	$valid_status_codes = [ 301, 302, 303, 307, 403, 404 ];
+	$valid_status_codes = [ 301, 302, 303, 307, ];
 	$status_code_labels = [
 		301 => 'Moved Permanently',
 		302 => 'Found',
 		303 => 'See Other',
 		307 => 'Temporary Redirect',
-		403 => 'Forbidden',
-		404 => 'Not Found',
 	];
 
 	/**

--- a/tests/class-admin-test.php
+++ b/tests/class-admin-test.php
@@ -34,13 +34,13 @@ class Admin_Test extends WP_UnitTestCase {
 		// All data set.
 		$_POST['hm_redirects_from_url']    = 'http://example.com/from';
 		$_POST['hm_redirects_to_url']      = 'http://example.com/to';
-		$_POST['hm_redirects_status_code'] = '403';
+		$_POST['hm_redirects_status_code'] = '301';
 		$this->assertTrue( Admin_UI\handle_redirect_saving( $redirect_post_id ) );
 
 		$saved_data = get_post( $redirect_post_id );
 		$this->assertSame( Utilities\get_url_hash( '/from' ), $saved_data->post_name );
 		$this->assertSame( '/from', $saved_data->post_title );
 		$this->assertSame( 'http://example.com/to', $saved_data->post_excerpt );
-		$this->assertSame( '403', $saved_data->post_content_filtered );
+		$this->assertSame( '301', $saved_data->post_content_filtered );
 	}
 }


### PR DESCRIPTION
The code doesn't support error codes 403 and 404, but the dropdown allows you to select them. This change removes those choices.

The single unit test uses 403 code as its test data. Changed to 301. Note: The unit test cannot be run as they rely on a 4-year-old docker image that no longer works.

Fixes https://github.com/humanmade/hm-redirects/issues/68
