### PR TITLE
Bump plugin version

### DIFF
--- a/hm-redirects.php
+++ b/hm-redirects.php
@@ -5,7 +5,7 @@
  * @package hm-redirects
  *
  * Description: Handles redirects in a scalable manner.
- * Version: 0.7.3
+ * Version: 0.7.4
  * Author: Human Made Limited
  * Author URI: https://humanmade.com/
  * Text Domain: hm-redirects


### PR DESCRIPTION
I'd like to release a new version. This plugin requires an old version of composer-installers and that is blocking me from using it - however this is fixed in `main` we just need to tag and release a new version.