### PR TITLE
Clarify 302 HTTP status code meaning

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -120,7 +120,7 @@ function output_meta_box( WP_Post $post ) {
 	$valid_status_codes = [ 301, 302, 303, 307, ];
 	$status_code_labels = [
 		301 => 'Moved Permanently',
-		302 => 'Found',
+		302 => 'Found (Moved temporarily)',
 		303 => 'See Other',
 		307 => 'Temporary Redirect',
 	];


### PR DESCRIPTION
This change adds in a reference to the old name of the 302 status code. to help distinguish it from the 307 status code.

![CleanShot 2025-05-09 at 15 32 46](https://github.com/user-attachments/assets/1a10589f-c6c0-4ca4-852b-b183c8f946a6)


Fixes: https://github.com/humanmade/hm-redirects/issues/80