### PR TITLE
trailing-slash: fix #74, revert #82

### DIFF
--- a/includes/handle-redirects.php
+++ b/includes/handle-redirects.php
@@ -86,6 +86,11 @@ function get_redirect_uri( $url ) {
 		return false;
 	}
 
+	if ($to_url[0] === '/') {
+		// It's a local URL. WordPress
+		$to_url = trailingslashit($to_url);
+	}
+
 	// If the URL is only a path, prefix it with the `home_url()`.
 	$to_url = Utilities\prefix_path( $to_url );
 

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -47,15 +47,9 @@ function sanitise_and_normalise_url( $unsafe_url ) {
 		$unsafe_url = add_leading_slash( $unsafe_url );
 	}
 
-	// Preserve trailing slash if it exists.
-	$has_trailing_slash = substr( $unsafe_url, -1 ) === '/';
-	if ( $has_trailing_slash ) {
-		// If the input URL has 1+ trailing slashes, we preserve exactly one.
-		$unsafe_url = trailingslashit( $unsafe_url );
-	}
-
 	// Strip query string, hash location and trailing slash.
 	$unsafe_url = strtok( $unsafe_url, '?#' );
+	$unsafe_url = rtrim( $unsafe_url, '/' );
 
 	// We now can safely escape the URL.
 	$url = esc_url_raw( $unsafe_url );


### PR DESCRIPTION
- Add a trailing-slash for local destination URL to avoid _"double-redirection"_ scenario, fix #74
- revert 4a6431e and 23d23cf (introduced with PR #82) which actually caused a regression where trailing-slash URL having a query-string were missed